### PR TITLE
enable css modules in css loader

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,14 @@ module.exports = {
         '@storybook/addon-links',
         '@storybook/addon-essentials',
         '@storybook/addon-postcss',
-        '@storybook/preset-scss',
+        {
+            name: '@storybook/preset-scss',
+            options: {
+                cssLoaderOptions: {
+                    modules: true,
+                }
+            }
+        },
         '@geometricpanda/storybook-addon-iframe',
         '@geometricpanda/storybook-addon-badges',
     ],


### PR DESCRIPTION
This PR adds `cssLoaderOptions` to `.storybook/main.js`. setting
`modules: true` enables CSS Modules which are used in
`wix-storybook-utils`.

Such configuration enables the styling of wix-storybook-utils